### PR TITLE
refactor: 不要なfileパラメータを削除し、TODOファイルを除外処理に追加

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -76,11 +76,11 @@ export default class LineTodoCollectorPlugin extends Plugin {
       this.app.vault.on("modify", async (file: TAbstractFile) => {
         if (!(file instanceof TFile) || !file.path.endsWith(".md")) return;
 
+        // TODOファイルは除外
+        if (file.path === OUTPUT_FILE) return;
+
         const content = await this.app.vault.read(file as TFile);
-        const newContent = await this.processCompletedTodos(
-          content,
-          file as TFile
-        );
+        const newContent = await this.processCompletedTodos(content);
 
         if (content !== newContent) {
           await this.app.vault.modify(file as TFile, newContent);
@@ -135,6 +135,11 @@ export default class LineTodoCollectorPlugin extends Plugin {
       console.log(`Found ${files.length} files in ${normalizedDir}`);
 
       for (const file of files) {
+        // TODOファイルは除外
+        if (file.path === OUTPUT_FILE) {
+          continue;
+        }
+
         const content = await vault.read(file);
         const lines = content.split("\n");
         let fileModified = false;
@@ -300,7 +305,7 @@ export default class LineTodoCollectorPlugin extends Plugin {
     }
   }
 
-  async processCompletedTodos(content: string, file: TFile): Promise<string> {
+  async processCompletedTodos(content: string): Promise<string> {
     const lines = content.split("\n");
     let modified = false;
     let result: string[] = [];

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -47,8 +47,7 @@ describe("LineTodoCollectorPlugin Integration Tests", () => {
 
       // 6. 完了済みTODOを処理
       const processedContent = await plugin.processCompletedTodos(
-        completedContent,
-        todoFile as any
+        completedContent
       );
 
       // 7. 完了済みTODOが削除されていることを確認

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -95,10 +95,7 @@ describe("LineTodoCollectorPlugin", () => {
       plugin.settings.completedTodoHandling = "immediate";
 
       const content = "# Sample\n- [x] 完了したタスク\n- [ ] 未完了タスク";
-      const result = await plugin.processCompletedTodos(
-        content,
-        new TFile("test.md") as any
-      );
+      const result = await plugin.processCompletedTodos(content);
 
       expect(result).not.toContain("- [x] 完了したタスク");
       expect(result).toContain("- [ ] 未完了タスク");
@@ -108,10 +105,7 @@ describe("LineTodoCollectorPlugin", () => {
       plugin.settings.completedTodoHandling = "keep";
 
       const content = "# Sample\n- [x] 完了したタスク\n- [ ] 未完了タスク";
-      const result = await plugin.processCompletedTodos(
-        content,
-        new TFile("test.md") as any
-      );
+      const result = await plugin.processCompletedTodos(content);
 
       expect(result).toContain("- [x] 完了したタスク");
       expect(result).toContain("- [ ] 未完了タスク");
@@ -126,10 +120,7 @@ describe("LineTodoCollectorPlugin", () => {
     test("フロントマターなしのファイルにフロントマターを追加できる", async () => {
       plugin.settings.completedTodoHandling = "keep";
       const content = "# Sample\n- [x] テストタスク";
-      const result = await plugin.processCompletedTodos(
-        content,
-        new TFile("test.md") as any
-      );
+      const result = await plugin.processCompletedTodos(content);
 
       expect(result).toContain("---");
       expect(result).toContain("add_todo: true");
@@ -143,10 +134,7 @@ describe("LineTodoCollectorPlugin", () => {
       console.log(content);
       console.log("=== END INPUT CONTENT ===");
 
-      const result = await plugin.processCompletedTodos(
-        content,
-        new TFile("test.md") as any
-      );
+      const result = await plugin.processCompletedTodos(content);
 
       console.log("=== TEST RESULT ===");
       console.log(result);


### PR DESCRIPTION
- processCompletedTodosメソッドから未使用のfileパラメータを削除
- onload()とcollectTodos()でTODOファイルを除外する処理を追加
- テストファイルのprocessCompletedTodos呼び出しを修正
- add_todoフラグを収集元ファイル専用の読み取り済みフラグとして明確化