### PR TITLE
fix: TodoHandlingの即時削除などの設定が正しく反映されるよう修正

### DIFF
--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -47,7 +47,8 @@ describe("LineTodoCollectorPlugin Integration Tests", () => {
 
       // 6. 完了済みTODOを処理
       const processedContent = await plugin.processCompletedTodos(
-        completedContent
+        completedContent,
+        "TODO.md"
       );
 
       // 7. 完了済みTODOが削除されていることを確認

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -95,7 +95,7 @@ describe("LineTodoCollectorPlugin", () => {
       plugin.settings.completedTodoHandling = "immediate";
 
       const content = "# Sample\n- [x] 完了したタスク\n- [ ] 未完了タスク";
-      const result = await plugin.processCompletedTodos(content);
+      const result = await plugin.processCompletedTodos(content, "TODO.md");
 
       expect(result).not.toContain("- [x] 完了したタスク");
       expect(result).toContain("- [ ] 未完了タスク");
@@ -105,7 +105,7 @@ describe("LineTodoCollectorPlugin", () => {
       plugin.settings.completedTodoHandling = "keep";
 
       const content = "# Sample\n- [x] 完了したタスク\n- [ ] 未完了タスク";
-      const result = await plugin.processCompletedTodos(content);
+      const result = await plugin.processCompletedTodos(content, "TODO.md");
 
       expect(result).toContain("- [x] 完了したタスク");
       expect(result).toContain("- [ ] 未完了タスク");
@@ -120,7 +120,7 @@ describe("LineTodoCollectorPlugin", () => {
     test("フロントマターなしのファイルにフロントマターを追加できる", async () => {
       plugin.settings.completedTodoHandling = "keep";
       const content = "# Sample\n- [x] テストタスク";
-      const result = await plugin.processCompletedTodos(content);
+      const result = await plugin.processCompletedTodos(content, "test.md");
 
       expect(result).toContain("---");
       expect(result).toContain("add_todo: true");
@@ -134,7 +134,7 @@ describe("LineTodoCollectorPlugin", () => {
       console.log(content);
       console.log("=== END INPUT CONTENT ===");
 
-      const result = await plugin.processCompletedTodos(content);
+      const result = await plugin.processCompletedTodos(content, "test.md");
 
       console.log("=== TEST RESULT ===");
       console.log(result);


### PR DESCRIPTION
- TODO.mdもon(modify)の監視対象に含めることで、チェックを付けた瞬間に完了済みTODOが消えるように
- processCompletedTodosのシグネチャを変更し、add_todoフラグの付与を収集元ファイルだけに限定
- テストも新しいシグネチャに対応